### PR TITLE
`--` is required between `gcloud docker` and `push`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The prefix for the version tags on git.
 
 #### DOCKER_PUSH_COMMAND
 
-Set `gcloud docker push` to push to [Google Cloud Registry](https://cloud.google.com/container-registry/docs/).
+Set `gcloud docker -- push` to push to [Google Cloud Registry](https://cloud.google.com/container-registry/docs/).
 
 #### DOCKER_PUSH_REGISTRY
 

--- a/lib/brocket/version.rb
+++ b/lib/brocket/version.rb
@@ -1,3 +1,3 @@
 module BRocket
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/brocket/Dockerfiles/Dockerfile-gcr
+++ b/spec/brocket/Dockerfiles/Dockerfile-gcr
@@ -1,6 +1,6 @@
 #
 # [config] IMAGE_NAME: "rails-example"
-# [config] DOCKER_PUSH_COMMAND: "gcloud docker push"
+# [config] DOCKER_PUSH_COMMAND: "gcloud docker -- push"
 # [config] DOCKER_PUSH_REGISTRY: "asia.gcr.io"
 # [config] DOCKER_PUSH_USERNAME: "groovenauts"
 #

--- a/spec/brocket/Dockerfiles/Dockerfile-push-extra-tag
+++ b/spec/brocket/Dockerfiles/Dockerfile-push-extra-tag
@@ -1,7 +1,7 @@
 #
 # [config] IMAGE_NAME: "rails-example"
 # [config]
-# [config] DOCKER_PUSH_COMMAND: "gcloud docker push"
+# [config] DOCKER_PUSH_COMMAND: "gcloud docker -- push"
 # [config] DOCKER_PUSH_REGISTRY: "asia.gcr.io"
 # [config] DOCKER_PUSH_USERNAME: "groovenauts"
 # [config] DOCKER_PUSH_EXTRA_TAG: "latest"

--- a/spec/brocket/docker_spec.rb
+++ b/spec/brocket/docker_spec.rb
@@ -61,7 +61,7 @@ describe BRocket::Docker do
       it do
         expected_cmd = [
           "docker tag #{original_image_name}:#{version} #{gcr_image_name}:#{version}",
-          "gcloud docker push #{gcr_image_name}:#{version}"
+          "gcloud docker -- push #{gcr_image_name}:#{version}"
         ].join(' && ')
         expect(subject).to receive(:sh).with(expected_cmd)
         subject.push
@@ -82,8 +82,8 @@ describe BRocket::Docker do
         expected_cmd = [
           "docker tag #{original_image_name}:#{version} #{gcr_image_name}:#{version}",
           "docker tag #{original_image_name}:#{version} #{gcr_image_name}:latest",
-          "gcloud docker push #{gcr_image_name}:#{version}",
-          "gcloud docker push #{gcr_image_name}:latest",
+          "gcloud docker -- push #{gcr_image_name}:#{version}",
+          "gcloud docker -- push #{gcr_image_name}:latest",
         ].join(' && ')
         expect(subject).to receive(:sh).with(expected_cmd)
         subject.push


### PR DESCRIPTION
Fixes #17.

NOTE: This PR changes only document (and test), so users must modify Dockerfile like this:

```diff
--- a/sample_app/Dockerfile
+++ b/sample_app/Dockerfile
@@ -2,7 +2,7 @@
 # [config]
 # [config] GIT_TAG_PREFIX: "sample_app/"
 # [config]
-# [config] DOCKER_PUSH_COMMAND: "gcloud docker push"
+# [config] DOCKER_PUSH_COMMAND: "gcloud docker -- push"
 # [config] DOCKER_PUSH_REGISTRY: "gcr.io"
 # [config] DOCKER_PUSH_USERNAME: "gke-example-20170514"
 # [config] DOCKER_PUSH_EXTRA_TAG: "latest"
```